### PR TITLE
Установка плейсхолдеров исходя из параметров скрипта

### DIFF
--- a/core/components/ajaxform/elements/snippets/snippet.ajaxform.php
+++ b/core/components/ajaxform/elements/snippets/snippet.ajaxform.php
@@ -10,6 +10,20 @@ $tpl = $modx->getOption('form', $scriptProperties, 'tpl.AjaxForm.example', true)
 $formSelector = $modx->getOption('formSelector', $scriptProperties, 'ajax_form', true);
 if (!isset($placeholderPrefix)) {$placeholderPrefix = 'fi.';}
 
+/*placeholder set*/
+$af_ph_pref = $modx->getOption('af_ph_pref', $scriptProperties, 'af.', true);
+if (isset($af_phs)) {
+    $arr_ph=explode(',',$af_phs);
+    $ph_pair=array();
+    foreach($arr_ph as $val_ph){
+        $val_ph=trim($val_ph);
+        if(isset($$val_ph)){
+            $ph_pair[$val_ph]=$$val_ph;
+        }
+    }
+    $modx->setPlaceholders($ph_pair,$af_ph_pref);
+}
+
 /** @var modChunk $chunk */
 if (!$chunk = $modx->getObject('modChunk', array('name' => $tpl))) {
 	return $modx->lexicon('af_err_chunk_nf', array('name' => $tpl));


### PR DESCRIPTION
af_phs - список параметров для передачи в плейсхолдер
af_ph_pref - префикс плейсхолдера

Позволяет передать параметры из скрипта в чанк, для последующей обработки, необходимо когда надо вызывать несколько форм с разными содержаниями, например при создании лендинга, у нас на странице есть 5 форм, выглядят формы одинаково, но необходимо чтобы была обработка форм индивидуальная с индивидуальными заголовками и чтобы не плодить чанки используем плейсхолдеры передаваемые в один чанк для унификации
