### PR TITLE
fix bug with "submitVar" in FormIt snippet

### DIFF
--- a/assets/components/ajaxform/js/default.js
+++ b/assets/components/ajaxform/js/default.js
@@ -16,6 +16,17 @@ var AjaxForm = {
 			$(this).ajaxSubmit({
 				dataType: 'json'
 				,url: afConfig.actionUrl
+				,beforeSerialize: function(form, options) { 
+				    form.find(':submit').each(function() {
+		                        if(!form.find('input[type="hidden"][name = "' + $(this).attr('name') + '"]').length) {
+		                            $(form).append(
+		                                $("<input type='hidden'>").attr( { 
+		                                    name: $(this).attr('name'), 
+		                                    value: $(this).attr('value') })
+		                            );
+		                        }
+		                    })           
+		                }
 				,beforeSubmit: function(fields, form) {
 					form.find('.error').html('');
 					form.find('input,textarea,select,button').attr('disabled', true);


### PR DESCRIPTION
Input[type="submit"] не прикрепляются к запросу отсылаемому на сервер, и если указан параметр "submitVar" в вызове FormIt, то не срабатывает его метод "hasSubmission()". Этот код исправляет это дело.
