### PR TITLE
Косметическая работа с подсветкой ошибок

### DIFF
--- a/assets/components/ajaxform/js/default.js
+++ b/assets/components/ajaxform/js/default.js
@@ -75,6 +75,12 @@ var AjaxForm = {
             e.preventDefault();
             return false;
         });
+        
+        $(document).on('keypress change', '.error', function(e) {
+            var key = $(this).attr('name');
+            $(this).removeClass('error');
+            $('.error_' + key).html('').removeClass('error');
+        });
 
         $(document).on('reset', afConfig['formSelector'], function () {
             $(this).find('.error').html('');

--- a/assets/components/ajaxform/js/default.js
+++ b/assets/components/ajaxform/js/default.js
@@ -46,9 +46,13 @@ var AjaxForm = {
                     if (!response.success) {
                         AjaxForm.Message.error(response.message);
                         if (response.data) {
-                            var key, value;
+                            var key, value, focused;
                             for (key in response.data) {
                                 if (response.data.hasOwnProperty(key)) {
+                                    if (!focused) {
+                                        form.find('[name="' + key + '"]').focus();
+                                        focused = true;
+                                    }
                                     value = response.data[key];
                                     form.find('.error_' + key).html(value).addClass('error');
                                     form.find('[name="' + key + '"]').addClass('error');


### PR DESCRIPTION
Когда поля, содержащие ошибку, подсвечиваются, на первое ошибочное поле устанавливается фокус. После начала ввода текста в поле с ошибкой, класс error снимается, чтобы вводимые данные не были красным.

https://youtu.be/EoT0xWvFhEs