### PR TITLE
Добавление настройки clearFieldsOnSuccess

### DIFF
--- a/assets/components/ajaxform/js/default.js
+++ b/assets/components/ajaxform/js/default.js
@@ -67,7 +67,9 @@ var AjaxForm = {
                     else {
                         AjaxForm.Message.success(response.message);
                         form.find('.error').removeClass('error');
-                        form[0].reset();
+                        if (afConfig['clearFieldsOnSuccess'] == 1){
+                            form[0].reset();
+                        }
                         //noinspection JSUnresolvedVariable
                         if (typeof(grecaptcha) != 'undefined') {
                             //noinspection JSUnresolvedVariable

--- a/assets/components/ajaxform/js/default.js
+++ b/assets/components/ajaxform/js/default.js
@@ -67,7 +67,7 @@ var AjaxForm = {
                     else {
                         AjaxForm.Message.success(response.message);
                         form.find('.error').removeClass('error');
-                        if (afConfig['clearFieldsOnSuccess'] == 1){
+                        if (!!afConfig.clearFieldsOnSuccess) {
                             form[0].reset();
                         }
                         //noinspection JSUnresolvedVariable

--- a/core/components/ajaxform/model/ajaxform/ajaxform.class.php
+++ b/core/components/ajaxform/model/ajaxform/ajaxform.class.php
@@ -80,7 +80,7 @@ class AjaxForm
             'actionUrl' => str_replace('[[+assetsUrl]]', $this->config['assetsUrl'], $this->config['actionUrl']),
             'closeMessage' => $this->config['closeMessage'],
             'formSelector' => "form.{$this->config['formSelector']}",
-            'clearFieldsOnSuccess' => $this->modx->getOption('clearFieldsOnSuccess', $this->config, 1,false),
+            'clearFieldsOnSuccess' => $this->modx->getOption('clearFieldsOnSuccess', $this->config, 1, false),
             'pageId' => !empty($this->modx->resource)
                 ? $this->modx->resource->get('id')
                 : 0,


### PR DESCRIPTION
Добавляет поддержку настройки clearFieldsOnSuccess от FormIt, чтобы можно было очищать или не очищать форму при успешной отправке.
Если == 1 то форма очищается, Если == 0 то нет.